### PR TITLE
feat(patch): enable disable-backfill feature by default

### DIFF
--- a/patches/sigp/lighthouse/unstable.patch
+++ b/patches/sigp/lighthouse/unstable.patch
@@ -18,7 +18,8 @@ index 8cc20ab..77fd313 100644
  FROM rust:1.88.0-bullseye AS builder
  RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 +COPY . lighthouse
- ARG FEATURES
+-ARG FEATURES
++ARG FEATURES=network/disable-backfill
  ARG PROFILE=release
  ARG CARGO_USE_GIT_CLI=true
  ENV FEATURES=$FEATURES


### PR DESCRIPTION
## Summary
- Enables the `network/disable-backfill` Lighthouse feature by default in dimhouse builds
- Prevents historical block backfilling during sync, reducing sync time and storage
