### PR TITLE
feat: add kurtosis testing config and bump xatu-sidecar to v0.0.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,26 @@ scripts/         - Build, apply, save, update-deps, and validate scripts
 1. `scripts/apply-dimhouse-patch.sh` applies patches, copies overlay/xatu, copies ci/Dockerfile.ethpandaops, injects Cargo.toml deps via `scripts/update-deps.sh`, and disables upstream workflows
 2. `scripts/dimhouse-build.sh` orchestrates clone + apply + build (supports `--skip-build` for Docker CI)
 3. `scripts/save-patch.sh` strips overlay/CI/dep artifacts and generates a clean patch
+
+## Testing with Kurtosis
+
+`kurtosis-config.yaml` defines a local testnet with a dimhouse (lighthouse+xatu) node and a vanilla lighthouse node.
+The xatu config is inlined via `extra_files` with stdout output so events appear in container logs.
+
+```bash
+# Quick test (assumes ethpandaops/dimhouse:latest image exists):
+kurtosis run github.com/ethpandaops/ethereum-package --args-file kurtosis-config.yaml --enclave dimhouse
+
+# View xatu events:
+kurtosis service logs dimhouse cl-1-lighthouse-nethermind
+
+# Cleanup:
+kurtosis enclave rm -f dimhouse
+```
+
+Key notes:
+- The xatu config `type: stdout` requires a dummy `config.address` field to satisfy the Rust config parser (the Go side ignores it for stdout)
+- The `vc_image` must match `cl_image` since lighthouse VC shares the same binary
+- No ENTRYPOINT in the Docker image -- kurtosis passes `lighthouse beacon_node ...` / `lighthouse vc ...` as the full command
+- `libxatu.so` must be in the image at a path covered by `LD_LIBRARY_PATH` (e.g. `/usr/local/lib`)
+- Update `overlay/xatu/src/libxatu.so` when bumping xatu-sidecar version (build.rs only downloads if missing)

--- a/kurtosis-config.yaml
+++ b/kurtosis-config.yaml
@@ -1,0 +1,36 @@
+extra_files:
+  xatu-config.yaml: |
+    enabled: true
+    name: "dimhouse-node"
+
+    outputs:
+    - name: log
+      type: stdout
+      config:
+        address: "stdout"
+
+participants:
+  - el_type: nethermind
+    cl_type: lighthouse
+    cl_image: ethpandaops/dimhouse:latest
+    cl_extra_params:
+      - --xatu-config=/etc/dimhouse/xatu-config.yaml
+    cl_extra_mounts:
+      "/etc/dimhouse": "xatu-config.yaml"
+    vc_type: lighthouse
+    vc_image: ethpandaops/dimhouse:latest
+    count: 1
+  - el_type: nethermind
+    cl_type: lighthouse
+    count: 1
+
+network_params:
+  electra_fork_epoch: 1
+  fulu_fork_epoch: 2
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
+  churn_limit_quotient: 16
+  genesis_delay: 60
+
+additional_services:
+  - dora

--- a/overlay/xatu/build.rs
+++ b/overlay/xatu/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 // Version of xatu-sidecar to download from GitHub releases
 // Update this when new versions are released: https://github.com/ethpandaops/xatu-sidecar/releases
-const XATU_SIDECAR_VERSION: &str = "v0.0.5";
+const XATU_SIDECAR_VERSION: &str = "v0.0.6";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -43,8 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dest_file = target_dir.join(&profile).join(&lib_filename);
 
     if lib_file.exists() {
-        std::fs::copy(&lib_file, &dest_file)
-            .expect("Failed to copy libxatu to output directory");
+        std::fs::copy(&lib_file, &dest_file).expect("Failed to copy libxatu to output directory");
 
         // On macOS, fix the library install name to use @rpath for proper dynamic loading
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
Add kurtosis-config.yaml for local multi-client testnet testing with xatu sidecar stdout output. Update xatu-sidecar from v0.0.5 to v0.0.6. Document kurtosis testing workflow in README and CLAUDE.md.